### PR TITLE
Update README for available scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Genome Mapping Analysis
 
-This repository contains scripts for analyzing genome mapping data from SAM files. The scripts extract mapping information, filter genes based on mapped reads, and identify multi-mapped reads.
+This repository contains scripts for analyzing genome mapping data from SAM files. The scripts extract mapping information, summarize mapped reads across genes, and identify multi-mapped reads.
 
 ## Structure
 
-- `scripts/`: Contains the Python scripts for data processing and analysis.
+- `Scripts/`: Contains the Python scripts for data processing and analysis.
 - `data/`: Directory to store input SAM files.
 - `results/`: Directory to store output CSV files.
 
 ## Scripts
 
-### 1. Gene Filtering
-
-The `gene_filtering.py` script loads SAM files, merges mapping data, and filters genes based on mapped read thresholds.
-
-### 2. Multi-Mapper Analysis
+### 1. Multi-Mapper Analysis
 
 The `multi_mapper_analysis.py` script identifies and counts multi-mapped and unique-mapped reads in SAM files.
+
+### 2. Unmapped Analysis
+
+The `unmapped_analysis_script.py` script merges data from multiple SAM files, summarizes mapped reads per gene, and filters genes using read-count thresholds.
 
 ## Usage
 
@@ -25,14 +25,14 @@ The `multi_mapper_analysis.py` script identifies and counts multi-mapped and uni
     pip install -r requirements.txt
     ```
 
-2. Run the gene filtering script:
+2. Run the multi-mapper analysis script:
     ```bash
-    python scripts/gene_filtering.py
+    python Scripts/multi_mapper_analysis.py
     ```
 
-3. Run the multi-mapper analysis script:
+3. Run the unmapped analysis script:
     ```bash
-    python scripts/multi_mapper_analysis.py
+    python Scripts/unmapped_analysis_script.py
     ```
 
 ## Requirements


### PR DESCRIPTION
## Summary
- remove references to missing gene_filtering.py
- document multi_mapper_analysis.py and unmapped_analysis_script.py
- fix usage paths to Scripts directory

## Testing
- `python -m py_compile Scripts/multi_mapper_analysis.py Scripts/unmapped_analysis_script.py` *(fails: SyntaxError in Scripts/unmapped_analysis_script.py line 21)*

------
https://chatgpt.com/codex/tasks/task_e_68941eda8fb08321908b0b3be5a7eff6