### PR TITLE
Wrap script execution in main

### DIFF
--- a/Scripts/multi_mapper_analysis.py
+++ b/Scripts/multi_mapper_analysis.py
@@ -18,24 +18,36 @@ def count_multi_mappers(sam_file):
             mapping_info['unique_mapped'].append(1)
     return pd.DataFrame(mapping_info).drop_duplicates(subset=['gene_id'])
 
-# Count multi-mappers and unique-mappers in each SAM file
-df_6A = count_multi_mappers("data/6A.sam")
-df_6U = count_multi_mappers("data/6U.sam")
-df_EA = count_multi_mappers("data/EA.sam")
-df_EU = count_multi_mappers("data/EU.sam")
 
-# Combine all DataFrames
-merged_df = df_6A.set_index('gene_id').add(df_6U.set_index('gene_id'), fill_value=0) \
-                 .add(df_EA.set_index('gene_id'), fill_value=0) \
-                 .add(df_EU.set_index('gene_id'), fill_value=0) \
-                 .reset_index()
+def main():
+    """Run multi-mapper and unique-mapper analysis on SAM files."""
+    # Count multi-mappers and unique-mappers in each SAM file
+    df_6A = count_multi_mappers("data/6A.sam")
+    df_6U = count_multi_mappers("data/6U.sam")
+    df_EA = count_multi_mappers("data/EA.sam")
+    df_EU = count_multi_mappers("data/EU.sam")
 
-# Summarize the total counts
-merged_df['total_multi_mapped'] = merged_df['multi_mapped'] + merged_df['unique_mapped']
-merged_df['total_unique_mapped'] = merged_df['unique_mapped']
+    # Combine all DataFrames
+    merged_df = (
+        df_6A.set_index('gene_id')
+        .add(df_6U.set_index('gene_id'), fill_value=0)
+        .add(df_EA.set_index('gene_id'), fill_value=0)
+        .add(df_EU.set_index('gene_id'), fill_value=0)
+        .reset_index()
+    )
 
-# Print the first few rows of the DataFrame
-print(merged_df.head())
+    # Summarize the total counts
+    merged_df['total_multi_mapped'] = (
+        merged_df['multi_mapped'] + merged_df['unique_mapped']
+    )
+    merged_df['total_unique_mapped'] = merged_df['unique_mapped']
 
-# Save the merged DataFrame to a CSV file
-merged_df.to_csv("results/merged_mapping_info.csv", index=False)
+    # Print the first few rows of the DataFrame
+    print(merged_df.head())
+
+    # Save the merged DataFrame to a CSV file
+    merged_df.to_csv("results/merged_mapping_info.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap multi-mapper analysis script execution in a `main()` with a `__main__` guard to keep helper function importable
- refactor unmapped analysis script into importable helpers and a guarded `main()`

## Testing
- `python -m py_compile Scripts/multi_mapper_analysis.py Scripts/unmapped_analysis_script.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941eeae53c8321805afe2673f75027